### PR TITLE
spu: Add test for RAM reads/writes using SyncMode 0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 [Jakub Czekański](https://github.com/JaCzekanski)
+[Connor McLaughlin](https://github.com/stenzek)

--- a/common/dma.hpp
+++ b/common/dma.hpp
@@ -126,12 +126,12 @@ union CHCR {
         return control;
     }
 
-    static CHCR SPUwrite() {
+    static CHCR SPUwrite(SyncMode syncMode = SyncMode::syncBlockToDmaRequests) {
         CHCR control;
         control.direction = Direction::fromRam;
         control.memoryAddressStep = MemoryAddressStep::forward;
         control.choppingEnable = 0;
-        control.syncMode = SyncMode::syncBlockToDmaRequests;
+        control.syncMode = syncMode;
         control.choppingDmaWindowSize = 0;
         control.choppingCpuWindowSize = 0;
         control.enabled = Enabled::start;
@@ -139,12 +139,12 @@ union CHCR {
         return control;
     }
 
-    static CHCR SPUread() {
+    static CHCR SPUread(SyncMode syncMode = SyncMode::syncBlockToDmaRequests) {
         CHCR control;
         control.direction = Direction::toRam;
         control.memoryAddressStep = MemoryAddressStep::forward;
         control.choppingEnable = 0;
-        control.syncMode = SyncMode::syncBlockToDmaRequests;
+        control.syncMode = syncMode;
         control.choppingDmaWindowSize = 0;
         control.choppingCpuWindowSize = 0;
         control.enabled = Enabled::start;


### PR DESCRIPTION
Nocash documentation states that bit 28 of DMA CHCR is used in sync mode 0 to start the transfer. However, this is not the whole story. I suspect this bit is only needed for the OTC channel (and maps to the request line) as this test shows that even without the bit set, transfers to the SPU still go through for both reads and writes.