### PR TITLE
cdrom: add disc-swap test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TOPTARGETS = build clean
 
 IMAGES = common \
+		cdrom/disc-swap \
 		cpu/access-time \
 		cpu/code-in-scratchpad \
 		dma/otc-test \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Collection of PlayStation 1 tests for emulator development and hardware verifica
 
 ## Tests
 
+### CD-ROM
+
+Name                     | Description
+-------------------------|------------
+disc-swap                | Program to observe behavior of CD-ROM controller when opening/closing the drive cover.
+
 ### CPU
 
 Name                     | Description

--- a/cdrom/disc-swap/Makefile
+++ b/cdrom/disc-swap/Makefile
@@ -1,0 +1,4 @@
+TARGET = disc-swap.elf
+LIBS  += -lpsxspu -lpsxcd
+
+include ../../common-test.mk

--- a/cdrom/disc-swap/main.cpp
+++ b/cdrom/disc-swap/main.cpp
@@ -1,0 +1,62 @@
+#include <common.h>
+#include <dma.hpp>
+#include <io.h>
+#include <psxcd.h>
+#include <psxpad.h>
+#include <psxapi.h>
+#include <psxetc.h>
+
+// Basic test to determine behavior of CD-ROM controller when the lid is opened.
+
+void wait_for_disc() {
+  unsigned char last_result = 0xFF;
+  bool first = true;
+  for (;;)
+  {
+    unsigned char result[4] = {};
+    if (!CdControl(CdlNop, nullptr, result))
+      continue;
+
+    if (result[0] != last_result || first) {
+      printf("> Getstat: 0x%02X\n", result[0]);
+      last_result = result[0];
+      first = false;
+    }
+
+    if (!(last_result & 0x10))
+      break;
+  }
+}
+
+int main() {
+  initVideo(320, 240);
+  printf("\ncdrom/disc-swap\n");
+  clearScreen();
+
+  for (;;) {
+    printf("> Init CD\n");
+    CdInit();
+
+    unsigned char status;
+    int irq = CdSync(1, &status);
+    printf("> CD IRQ=%d, status=0x%02X\n", irq, status);
+
+    if (status & 0x10) {
+      printf("> Waiting for disc to be inserted...\n");
+      wait_for_disc();
+    }
+
+    printf("*** Open the shell now ***\n");
+
+    int last_irq = irq;
+    while (last_irq == irq)
+      irq = CdSync(1, &status);
+    printf("> Got IRQ %d (expected 5), status 0x%02X\n", irq, status);
+
+    printf("*** Close the shell now ***\n");
+    wait_for_disc();
+    printf("> Disc detected\n");
+  }
+
+  return 0;
+}

--- a/cdrom/disc-swap/psx.log
+++ b/cdrom/disc-swap/psx.log
@@ -1,0 +1,11 @@
+cdrom/disc-swap
+> Init CD
+psxcd: Init Ok!
+> CD IRQ=2, status=0x02
+*** Open the shell now ***
+> Got IRQ 5 (expected 5), status 0x01
+*** Close the shell now ***
+> Getstat: 0x12
+> Getstat: 0x10
+> Getstat: 0x00
+> Disc inserted?


### PR DESCRIPTION
Simple program to observe the behavior of the CD-ROM controller when the cover is opened/closed.

Code isn't pretty, it's more of a program to run and observe rather than testing an emulator, although the output can be compared. I'm not really sure how we could run it as a unit test anyway, unless we created an hypercall-style interface somewhere in the address space which could trigger disc removals/insertions.